### PR TITLE
Implement Receive-SbMessagesInBatch

### DIFF
--- a/PSServiceBus.psd1
+++ b/PSServiceBus.psd1
@@ -73,7 +73,7 @@ FunctionsToExport = 'Save-SbConnectionString'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = 'Get-SbQueue', 'Get-SbTopic', 'Get-SbSubscription', 'Send-SbMessage', 
-               'Receive-SbMessage', 'Test-SbConnectionString'
+               'Receive-SbMessage', 'Receive-SbMessagesInBatch', 'Test-SbConnectionString'
 
 # Variables to export from this module
 # VariablesToExport = @()

--- a/src/PSServiceBus/Cmdlets/ReceiveSbMessagesInBatch.cs
+++ b/src/PSServiceBus/Cmdlets/ReceiveSbMessagesInBatch.cs
@@ -7,7 +7,7 @@ using PSServiceBus.Enums;
 namespace PSServiceBus.Cmdlets
 {
     /// <summary>
-    /// <para type="synopsis">Receivess messages in batch from an Azure Service Bus queue or subscription.</para>
+    /// <para type="synopsis">Receives messages in batch from an Azure Service Bus queue or subscription.</para>
     /// <para type="description">This cmdlet retrieves messages in batch from an Azure Service Bus queue or subscription. Two receive modes are available:</para>
     /// <para type="description">ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue.  Multiple messages can be</para>
     /// <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline. Messages can also be</para>

--- a/src/PSServiceBus/Cmdlets/ReceiveSbMessagesInBatch.cs
+++ b/src/PSServiceBus/Cmdlets/ReceiveSbMessagesInBatch.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Generic;
+using System.Management.Automation;
+using PSServiceBus.Helpers;
+using PSServiceBus.Outputs;
+using PSServiceBus.Enums;
+
+namespace PSServiceBus.Cmdlets
+{
+    /// <summary>
+    /// <para type="synopsis">Receivess messages in batch from an Azure Service Bus queue or subscription.</para>
+    /// <para type="description">This cmdlet retrieves messages in batch from an Azure Service Bus queue or subscription. Two receive modes are available:</para>
+    /// <para type="description">ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue.  Multiple messages can be</para>
+    /// <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline. Messages can also be</para>
+    /// <para type="description">received from the dead letter queue by adding the -ReceiveFromDeadLetterQueue parameter.</para>
+    /// </summary>
+    /// <example>
+    /// <code>Receive-SbMessagesInBatch -NamespaceConnectionString $namespaceConnectionString -QueueName 'example-queue'</code>
+    /// <para>Receives a single message in batch from the queue 'example-queue' and leaves it there</para>
+    /// <para></para>
+    /// </example>
+    /// <example>
+    /// <code>Receive-SbMessagesInBatch -NamespaceConnectionString $namespaceConnectionString -TopicName 'example-topic' -SubscriptionName 'example-subscription' -ReceiveQty 5</code>
+    /// <para>Receives 5 messages in batch from the subscription called 'example-subscription' in the topic 'example-topic' and leaves them there</para>
+    /// <para></para>
+    /// </example>
+    /// <example>
+    /// <code>Receive-SbMessagesInBatch -NamespaceConnectionString $namespaceConnectionString -QueueName 'example-queue' -ReceiveType ReceiveAndDelete</code>
+    /// <para>Receives a single message in batch from the queue 'example-queue' and removes it from the queue</para>
+    /// <para></para>
+    /// </example>
+    /// <example>
+    /// <code>Receive-SbMessagesInBatch -NamespaceConnectionString $namespaceConnectionString -QueueName 'example-queue' -ReceiveFromDeadLetterQueue</code>
+    /// <para>Receives a single message in batch from the dead letter queue for queue 'example-queue' and leaves it there</para>
+    /// <para></para>
+    /// </example>
+    [Cmdlet(VerbsCommunications.Receive, "SbMessagesInBatch")]
+    [OutputType(typeof(SbMessage))]
+    public class ReceiveSbMessagesInBatch : PSCmdlet
+    {
+        /// <summary>
+        /// <para type="description">A connection string with 'Manage' rights for the Azure Service Bus Namespace.</para>
+        /// </summary>
+        [Parameter(Mandatory = true)]
+        public string NamespaceConnectionString { get; set; }
+
+        /// <summary>
+        /// <para type="description">The name of the queue to retrieve messages from.</para>
+        /// </summary>
+        [Parameter(
+            Mandatory = true,
+            ParameterSetName = "ReceiveFromQueue"
+        )]
+        public string QueueName { get; set; }
+
+        /// <summary>
+        /// <para type="description">The name of the topic containing the subscription to retrieve messages from.</para>
+        /// </summary>
+        [Parameter(
+            Mandatory = true,
+            ParameterSetName = "ReceiveFromSubscription"
+        )]
+        public string TopicName { get; set; }
+
+        /// <summary>
+        /// <para type="description">The name of the subscription to retrieve messages from.</para>
+        /// </summary>
+        [Parameter(
+            Mandatory = true,
+            ParameterSetName = "ReceiveFromSubscription"
+        )]
+        public string SubscriptionName { get; set; }
+
+        /// <summary>
+        /// <para type="description">The number of messages to retrieve - defaults to 1.</para>
+        /// </summary>
+        [Parameter]
+        public int ReceiveQty { get; set; } = 1;
+
+        /// <summary>
+        /// <para type="description">Specifies the receive behaviour - defaults to ReceiveAndKeep.</para>
+        /// </summary>
+        [Parameter]
+        public SbReceiveTypes ReceiveType { get; set; } = SbReceiveTypes.ReceiveAndKeep;
+
+        /// <summary>
+        /// <para type="description">Retrieves messages from the entity's dead letter queue.</para>
+        /// </summary>
+        [Parameter]
+        public SwitchParameter ReceiveFromDeadLetterQueue { get; set; }
+
+        /// <summary>
+        /// Main cmdlet method.
+        /// </summary>
+        protected override void ProcessRecord()
+        {
+            SbReceiver sbReceiver;
+            SbManager sbManager = new SbManager(NamespaceConnectionString);
+
+            if (this.ParameterSetName == "ReceiveFromQueue")
+            {
+                sbReceiver = new SbReceiver(NamespaceConnectionString, QueueName, ReceiveFromDeadLetterQueue, sbManager);
+            }
+            else
+            {
+                sbReceiver = new SbReceiver(NamespaceConnectionString, TopicName, SubscriptionName, ReceiveFromDeadLetterQueue, sbManager);
+            }
+
+            IList<SbMessage> sbMessages = sbReceiver.ReceiveMessagesInBatch(ReceiveQty, ReceiveType);
+
+            foreach (SbMessage sbMessage in sbMessages)
+            {
+                WriteObject(sbMessage);
+            }
+        }
+    }
+}

--- a/src/PSServiceBus/Helpers/SbReceiver.cs
+++ b/src/PSServiceBus/Helpers/SbReceiver.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.ServiceBus.Core;
 using PSServiceBus.Outputs;
 using PSServiceBus.Enums;
 using PSServiceBus.Exceptions;
+using System.Linq;
 
 namespace PSServiceBus.Helpers
 {
@@ -69,6 +70,21 @@ namespace PSServiceBus.Helpers
             }
         }
 
+        public IList<SbMessage> ReceiveMessagesInBatch(int NumberOfMessages, SbReceiveTypes ReceiveType)
+        {
+            switch (ReceiveType)
+            {
+                case SbReceiveTypes.ReceiveAndKeep:
+                    return this.PeekMessagesInBatch(NumberOfMessages);
+
+                case SbReceiveTypes.ReceiveAndDelete:
+                    return this.ReceiveAndDeleteInBatch(NumberOfMessages);
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
         private IList<SbMessage> PeekMessages(int NumberOfMessages)
         {
             IList<Message> messages = new List<Message>();
@@ -85,6 +101,23 @@ namespace PSServiceBus.Helpers
                 {
                     break;
                 }
+            }
+            
+            return BuildMessageList(messages);
+        }
+
+        private IList<SbMessage> PeekMessagesInBatch(int NumberOfMessages)
+        {
+            IList<Message> messages = null;
+
+            try
+            {
+                messages = messageReceiver.PeekAsync(NumberOfMessages).Result;
+            }
+            catch (Exception E)
+            {
+                messages = new List<Message>();
+                throw new Exception("Something while peeking for messages in batch against the Service Bus.", E);
             }
             
             return BuildMessageList(messages);
@@ -107,6 +140,28 @@ namespace PSServiceBus.Helpers
                 {
                     break;
                 }
+            }
+
+            return BuildMessageList(messages);
+        }
+
+        private IList<SbMessage> ReceiveAndDeleteInBatch(int NumberOfMessages)
+        {
+            IList<Message> messages = null;
+
+            try
+            {
+                messages = messageReceiver.ReceiveAsync(NumberOfMessages).Result;
+
+                if(messages != null && messages.Count > 0)
+                {
+                    messageReceiver.CompleteAsync(messages.Select(x => x.SystemProperties.LockToken).ToList());
+                }
+            }
+            catch (Exception E)
+            {
+                messages = new List<Message>();
+                throw new Exception("Something while Receiving & Deleting messages in batch against the Service Bus.", E); ;
             }
 
             return BuildMessageList(messages);

--- a/src/PSServiceBus/PSServiceBus.xml
+++ b/src/PSServiceBus/PSServiceBus.xml
@@ -165,6 +165,75 @@
             Main cmdlet method.
             </summary>
         </member>
+        <member name="T:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch">
+            <summary>
+            <para type="synopsis">Receivess messages in batch from an Azure Service Bus queue or subscription.</para>
+            <para type="description">This cmdlet retrieves messages in batch from an Azure Service Bus queue or subscription. Two receive modes are available:</para>
+            <para type="description">ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue.  Multiple messages can be</para>
+            <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline. Messages can also be</para>
+            <para type="description">received from the dead letter queue by adding the -ReceiveFromDeadLetterQueue parameter.</para>
+            </summary>
+            <example>
+            <code>Receive-SbMessagesInBatch -NamespaceConnectionString $namespaceConnectionString -QueueName 'example-queue'</code>
+            <para>Receives a single message in batch from the queue 'example-queue' and leaves it there</para>
+            <para></para>
+            </example>
+            <example>
+            <code>Receive-SbMessagesInBatch -NamespaceConnectionString $namespaceConnectionString -TopicName 'example-topic' -SubscriptionName 'example-subscription' -ReceiveQty 5</code>
+            <para>Receives 5 messages in batch from the subscription called 'example-subscription' in the topic 'example-topic' and leaves them there</para>
+            <para></para>
+            </example>
+            <example>
+            <code>Receive-SbMessagesInBatch -NamespaceConnectionString $namespaceConnectionString -QueueName 'example-queue' -ReceiveType ReceiveAndDelete</code>
+            <para>Receives a single message in batch from the queue 'example-queue' and removes it from the queue</para>
+            <para></para>
+            </example>
+            <example>
+            <code>Receive-SbMessagesInBatch -NamespaceConnectionString $namespaceConnectionString -QueueName 'example-queue' -ReceiveFromDeadLetterQueue</code>
+            <para>Receives a single message in batch from the dead letter queue for queue 'example-queue' and leaves it there</para>
+            <para></para>
+            </example>
+        </member>
+        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch.NamespaceConnectionString">
+            <summary>
+            <para type="description">A connection string with 'Manage' rights for the Azure Service Bus Namespace.</para>
+            </summary>
+        </member>
+        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch.QueueName">
+            <summary>
+            <para type="description">The name of the queue to retrieve messages from.</para>
+            </summary>
+        </member>
+        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch.TopicName">
+            <summary>
+            <para type="description">The name of the topic containing the subscription to retrieve messages from.</para>
+            </summary>
+        </member>
+        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch.SubscriptionName">
+            <summary>
+            <para type="description">The name of the subscription to retrieve messages from.</para>
+            </summary>
+        </member>
+        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch.ReceiveQty">
+            <summary>
+            <para type="description">The number of messages to retrieve - defaults to 1.</para>
+            </summary>
+        </member>
+        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch.ReceiveType">
+            <summary>
+            <para type="description">Specifies the receive behaviour - defaults to ReceiveAndKeep.</para>
+            </summary>
+        </member>
+        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch.ReceiveFromDeadLetterQueue">
+            <summary>
+            <para type="description">Retrieves messages from the entity's dead letter queue.</para>
+            </summary>
+        </member>
+        <member name="M:PSServiceBus.Cmdlets.ReceiveSbMessagesInBatch.ProcessRecord">
+            <summary>
+            Main cmdlet method.
+            </summary>
+        </member>
         <member name="T:PSServiceBus.Cmdlets.SendSbMessage">
             <summary>
             <para type="synopsis">Sends a message to an Azure Service Bus queue or topic.</para>

--- a/tests/integration/Receive-SbMessagesInBatch.tests.ps1
+++ b/tests/integration/Receive-SbMessagesInBatch.tests.ps1
@@ -1,0 +1,174 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [PSServiceBus.Tests.Utils.ServiceBusUtils]
+    $ServiceBusUtils
+)
+
+Describe "Receive-SbMessagesInBatch tests" {
+
+    # setup
+
+    # create some queues, topics and subscriptions and allow time for it to complete
+
+    $queues = $ServiceBusUtils.CreateQueues(4)
+
+    $testTopic = (New-Guid).Guid
+    $ServiceBusUtils.CreateTopic($testTopic)
+
+    $subscriptions = $ServiceBusUtils.CreateSubscriptions($testTopic, 4)
+
+    # send some messages to the queues and the topic and dead letter a portion of them
+
+    $messagesToSendToEachEntity = 5
+    $messagesToDeadLetter = 2
+
+    foreach ($queue in $queues)
+    {
+        for ($i = 0; $i -lt $messagesToSendToEachEntity; $i++)
+        {
+            $ServiceBusUtils.SendTestMessage($queue)
+        }
+
+        for ($i = 0; $i -lt $messagesToDeadLetter; $i++)
+        {
+            $ServiceBusUtils.ReceiveAndDeadLetterAMessage($queue)
+        }
+    }
+
+    for ($i = 0; $i -lt $messagesToSendToEachEntity; $i++)
+    {
+        $ServiceBusUtils.SendTestMessage($testTopic)
+    }
+    
+    foreach ($subscription in $subscriptions)
+    {
+        $subscriptionPath = $ServiceBusUtils.BuildSubscriptionPath($testTopic, $subscription)
+
+        for ($i = 0; $i -lt $messagesToDeadLetter; $i++)
+        {
+            $ServiceBusUtils.ReceiveAndDeadLetterAMessage($subscriptionPath)
+        }
+    }
+
+    # tests
+
+    Context "Output type tests" {
+
+        It "should have an output type of PSServiceBus.Outputs.SbMessage" {
+            (Get-Command -Name "Receive-SbMessagesInBatch").OutputType.Name | Should -Be "PSServiceBus.Outputs.SbMessage" 
+        }
+        
+    }
+
+    Context "Test parameter attributes" {
+
+        It "QueueName parameter should be mandatory" {
+            (Get-Command -Name Receive-SbMessagesInBatch).Parameters['QueueName'].Attributes.Mandatory | Should -Be $true
+        }
+
+        It "TopicName parameter should be mandatory" {
+            (Get-Command -Name Receive-SbMessagesInBatch).Parameters['TopicName'].Attributes.Mandatory | Should -Be $true
+        }
+
+        It "SubscriptionName parameter should be mandatory" {
+            (Get-Command -Name Receive-SbMessagesInBatch).Parameters['SubscriptionName'].Attributes.Mandatory | Should -Be $true
+        }
+    }
+
+    Context "Test receiving from a queue" {
+
+        It "should receive a single message if -ReceiveQty is not supplied" {
+            $queue = $queues[0]
+            $result = Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue
+            $result.count | Should -Be 1
+        }
+
+        It "should receive the correct number of messages if -ReceiveQty is supplied" -TestCases @{messages = 2}, @{messages = 3} {
+            param ([int] $messages)
+            $queue = $queues[1]
+            $result = Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty $messages
+            $result.count | Should -Be $messages
+        }
+
+        It "should leave messages in the queue after being received if -ReceiveType is not supplied" {
+            $queue = $queues[2]
+            Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty 2
+            $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter)
+        }
+
+        It "should remove messages from the queue after being received if -ReceiveType ReceiveAndDelete is supplied" {
+            $queue = $queues[2]
+            $messagesToRemove = 2
+            Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty $messagesToRemove -ReceiveType ReceiveAndDelete
+            Start-Sleep -Seconds 1
+            $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter - $messagesToRemove)
+        }
+
+        It "should receive messages from the dead letter queue if -ReceiveFromDeadLetterQueue is supplied" {
+            $queue = $queues[3]
+            $messagesToReceive = 1
+            Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty $messagesToReceive -ReceiveType ReceiveAndDelete -ReceiveFromDeadLetterQueue
+            Start-Sleep -Seconds 1
+            $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.DeadLetterMessageCount | Should -Be ($messagesToDeadLetter - $messagesToReceive)
+        }
+    }
+
+    Context "Test receiving from a subscription" {
+
+        It "should receive a single message if -ReceiveQty is not supplied" {
+            $subscription = $subscriptions[0]
+            $result = Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription
+            $result.count | Should -Be 1
+        }
+
+        It "should receive the correct number of messages if -ReceiveQty is supplied" -TestCases @{messages = 2}, @{messages = 3} {
+            param ([int] $messages)
+            $subscription = $subscriptions[1]
+            $result = Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -ReceiveQty $messages
+            $result.count | Should -Be $messages
+        }
+
+        It "should leave messages in the subscription after being received if -ReceiveType is not supplied" {
+            $subscription = $subscriptions[2]
+            Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -ReceiveQty 2
+            $ServiceBusUtils.GetSubscriptionRuntimeInfo($testTopic, $subscription).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter)
+        }
+
+        It "should remove messages from the subscription after being received if -ReceiveType ReceiveAndDelete is supplied" {
+            $subscription = $subscriptions[2]
+            $messagesToRemove = 2
+            Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -ReceiveQty $messagesToRemove -ReceiveType ReceiveAndDelete
+            Start-Sleep -Seconds 1
+            $ServiceBusUtils.GetSubscriptionRuntimeInfo($testTopic, $subscription).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter - $messagesToRemove)
+        }
+
+        It "should receive messages from the dead letter queue if -ReceiveFromDeadLetterQueue is supplied" {
+            $subscription = $subscriptions[3]
+            $messagesToReceive = 1
+            Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -ReceiveQty $messagesToReceive -ReceiveType ReceiveAndDelete -ReceiveFromDeadLetterQueue
+            Start-Sleep -Seconds 1
+            $ServiceBusUtils.GetSubscriptionRuntimeInfo($testTopic, $subscription).MessageCountDetails.DeadLetterMessageCount | Should -Be ($messagesToDeadLetter - $messagesToReceive)
+        }
+    }
+
+    Context "Negative tests" {
+
+        It "should throw correct exception message when a non-existent queue is supplied" {
+            { Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName "non-existent" } | Should -Throw "Queue non-existent does not exist"
+        }
+
+        It "should throw correct exception message when a non-existent topic is supplied" {
+            { Receive-SbMessagesInBatch -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName "non-existent" -SubscriptionName 'non-existent' } | Should -Throw "Subscription non-existent does not exist in Topic non-existent"
+        }
+    }
+
+    # tear down
+
+    foreach ($queue in $queues)
+    {
+        $ServiceBusUtils.RemoveQueue($queue)
+    }
+
+    $ServiceBusUtils.RemoveTopic($testTopic)
+}


### PR DESCRIPTION
I believe that we need to support the batching pattern, where we fetch as many messages per round trip to the Service bus.

Please note that I changed the "NumberOfMessagesToRetrieve" parameter to "ReceiveQty". I would like to create an alias for the other receive cmdlet, but we can discuss that in an issue if you like.