### PR TITLE
add method to get the maximum message size for the namespace

### DIFF
--- a/src/PSServiceBus/Helpers/SbManager.cs
+++ b/src/PSServiceBus/Helpers/SbManager.cs
@@ -129,5 +129,23 @@ namespace PSServiceBus.Helpers
         {
             return EntityNameHelper.FormatDeadLetterPath(EntityPath);
         }
+
+        public int GetMessageMaxSizeInBytes()
+        {
+            MessagingSku sku = this.managementClient.GetNamespaceInfoAsync().Result.MessagingSku;
+
+            switch (sku)
+            {
+                case MessagingSku.Basic:
+                case MessagingSku.Standard:
+                    return 256000;
+                
+                case MessagingSku.Premium:
+                    return 1000000;
+
+                default:
+                    throw new NotImplementedException(string.Format("Maximum message size for sku '{0}' is unknown", sku.ToString()));
+            }
+        }
     }
 }


### PR DESCRIPTION
This is a small change that adds a new method to get the maximum size for a message (or batch of messages) for the in-scope namespace, as raised in #13.