### PR TITLE
Refactor NumberOfMessagesToRetrieve to ReceiveQty 

### DIFF
--- a/src/PSServiceBus/Cmdlets/ReceiveSbMessage.cs
+++ b/src/PSServiceBus/Cmdlets/ReceiveSbMessage.cs
@@ -74,6 +74,7 @@ namespace PSServiceBus.Cmdlets
         /// <para type="description">The number of messages to retrieve - defaults to 1.</para>
         /// </summary>
         [Parameter]
+        [Alias("NumberOfMessagesToRetrieve")]
         public int ReceiveQty { get; set; } = 1;
 
         /// <summary>

--- a/src/PSServiceBus/Cmdlets/ReceiveSbMessage.cs
+++ b/src/PSServiceBus/Cmdlets/ReceiveSbMessage.cs
@@ -8,9 +8,9 @@ namespace PSServiceBus.Cmdlets
 {
     /// <summary>
     /// <para type="synopsis">Receives a message or messages from an Azure Service Bus queue or subscription.</para>
-    /// <para type="description">This cmdlet retrieves a message or messages from an Azure Service Bus queue or subscription.  Two receive modes are available:</para>
-    /// <para type="description">PeekOnly/ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue.  Multiple messages can be</para>
-    /// <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline.  Messages can also be</para>
+    /// <para type="description">This cmdlet retrieves a message or messages from an Azure Service Bus queue or subscription. Two receive modes are available:</para>
+    /// <para type="description">PeekOnly/ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue. Multiple messages can be</para>
+    /// <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline. Messages can also be</para>
     /// <para type="description">received from the dead letter queue by adding the -ReceiveFromDeadLetterQueue parameter.</para>
     /// </summary>
     /// <example>

--- a/src/PSServiceBus/Cmdlets/ReceiveSbMessage.cs
+++ b/src/PSServiceBus/Cmdlets/ReceiveSbMessage.cs
@@ -10,7 +10,7 @@ namespace PSServiceBus.Cmdlets
     /// <para type="synopsis">Receives a message or messages from an Azure Service Bus queue or subscription.</para>
     /// <para type="description">This cmdlet retrieves a message or messages from an Azure Service Bus queue or subscription.  Two receive modes are available:</para>
     /// <para type="description">PeekOnly/ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue.  Multiple messages can be</para>
-    /// <para type="description">received using the -NumberOfMessagesToRetrieve parameter, they will be returned individually to the pipeline.  Messages can also be</para>
+    /// <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline.  Messages can also be</para>
     /// <para type="description">received from the dead letter queue by adding the -ReceiveFromDeadLetterQueue parameter.</para>
     /// </summary>
     /// <example>
@@ -19,7 +19,7 @@ namespace PSServiceBus.Cmdlets
     /// <para></para>
     /// </example>
     /// <example>
-    /// <code>Receive-SbMessage -NamespaceConnectionString $namespaceConnectionString -TopicName 'example-topic' -SubscriptionName 'example-subscription' -NumberOfMessagesToRetrieve 5</code>
+    /// <code>Receive-SbMessage -NamespaceConnectionString $namespaceConnectionString -TopicName 'example-topic' -SubscriptionName 'example-subscription' -ReceiveQty 5</code>
     /// <para>Receives 5 messages from the subscription called 'example-subscription' in the topic 'example-topic' and leaves them there</para>
     /// <para></para>
     /// </example>
@@ -74,7 +74,7 @@ namespace PSServiceBus.Cmdlets
         /// <para type="description">The number of messages to retrieve - defaults to 1.</para>
         /// </summary>
         [Parameter]
-        public int NumberOfMessagesToRetrieve { get; set; } = 1;
+        public int ReceiveQty { get; set; } = 1;
 
         /// <summary>
         /// <para type="description">Specifies the receive behaviour - defaults to PeekOnly.</para>
@@ -110,7 +110,7 @@ namespace PSServiceBus.Cmdlets
                 sbReceiver = new SbReceiver(NamespaceConnectionString, TopicName, SubscriptionName, ReceiveFromDeadLetterQueue, sbManager);
             }
 
-            IList<SbMessage> sbMessages = sbReceiver.ReceiveMessages(NumberOfMessagesToRetrieve, ReceiveType);
+            IList<SbMessage> sbMessages = sbReceiver.ReceiveMessages(ReceiveQty, ReceiveType);
 
             foreach (SbMessage sbMessage in sbMessages)
             {

--- a/src/PSServiceBus/PSServiceBus.xml
+++ b/src/PSServiceBus/PSServiceBus.xml
@@ -153,7 +153,7 @@
             <para type="synopsis">Receives a message or messages from an Azure Service Bus queue or subscription.</para>
             <para type="description">This cmdlet retrieves a message or messages from an Azure Service Bus queue or subscription.  Two receive modes are available:</para>
             <para type="description">PeekOnly/ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue.  Multiple messages can be</para>
-            <para type="description">received using the -NumberOfMessagesToRetrieve parameter, they will be returned individually to the pipeline.  Messages can also be</para>
+            <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline.  Messages can also be</para>
             <para type="description">received from the dead letter queue by adding the -ReceiveFromDeadLetterQueue parameter.</para>
             </summary>
             <example>
@@ -162,7 +162,7 @@
             <para></para>
             </example>
             <example>
-            <code>Receive-SbMessage -NamespaceConnectionString $namespaceConnectionString -TopicName 'example-topic' -SubscriptionName 'example-subscription' -NumberOfMessagesToRetrieve 5</code>
+            <code>Receive-SbMessage -NamespaceConnectionString $namespaceConnectionString -TopicName 'example-topic' -SubscriptionName 'example-subscription' -ReceiveQty 5</code>
             <para>Receives 5 messages from the subscription called 'example-subscription' in the topic 'example-topic' and leaves them there</para>
             <para></para>
             </example>
@@ -197,7 +197,7 @@
             <para type="description">The name of the subscription to retrieve messages from.</para>
             </summary>
         </member>
-        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessage.NumberOfMessagesToRetrieve">
+        <member name="P:PSServiceBus.Cmdlets.ReceiveSbMessage.ReceiveQty">
             <summary>
             <para type="description">The number of messages to retrieve - defaults to 1.</para>
             </summary>

--- a/src/PSServiceBus/PSServiceBus.xml
+++ b/src/PSServiceBus/PSServiceBus.xml
@@ -151,9 +151,9 @@
         <member name="T:PSServiceBus.Cmdlets.ReceiveSbMessage">
             <summary>
             <para type="synopsis">Receives a message or messages from an Azure Service Bus queue or subscription.</para>
-            <para type="description">This cmdlet retrieves a message or messages from an Azure Service Bus queue or subscription.  Two receive modes are available:</para>
-            <para type="description">PeekOnly/ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue.  Multiple messages can be</para>
-            <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline.  Messages can also be</para>
+            <para type="description">This cmdlet retrieves a message or messages from an Azure Service Bus queue or subscription. Two receive modes are available:</para>
+            <para type="description">PeekOnly/ReceiveAndKeep (default) and ReceiveAndDelete which if specified will remove the message from the queue. Multiple messages can be</para>
+            <para type="description">received using the -ReceiveQty parameter, they will be returned individually to the pipeline. Messages can also be</para>
             <para type="description">received from the dead letter queue by adding the -ReceiveFromDeadLetterQueue parameter.</para>
             </summary>
             <example>

--- a/tests/integration/Receive-SbMessage.tests.ps1
+++ b/tests/integration/Receive-SbMessage.tests.ps1
@@ -78,7 +78,7 @@ Describe "Receive-SbMessage tests" {
 
     Context "Test receiving from a queue" {
 
-        It "should receive a single message if -NumberOfMessagesToRetrieve is not supplied" {
+        It "should receive a single message if -ReceiveQty is not supplied" {
             $queue = $queues[0]
             $result = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue
             $result.count | Should -Be 1
@@ -96,41 +96,41 @@ Describe "Receive-SbMessage tests" {
             $null -eq $result.UserProperties | Should -be $false
         }
 
-        It "should receive the correct number of messages if -NumberOfMessagesToRetrieve is supplied" -TestCases @{messages = 2}, @{messages = 3} {
+        It "should receive the correct number of messages if -ReceiveQty is supplied" -TestCases @{messages = 2}, @{messages = 3} {
             param ([int] $messages)
             $queue = $queues[1]
-            $result = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -NumberOfMessagesToRetrieve $messages
+            $result = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty $messages
             $result.count | Should -Be $messages
         }
 
         It "should leave messages in the queue after being received if -ReceiveType is not supplied" {
             $queue = $queues[2]
-            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -NumberOfMessagesToRetrieve 2
+            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty 2
             $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter)
         }
 
         It "should leave messages in the queue after being received if -ReceiveType is PeekOnly" {
             $queue = $queues[3]
-            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -NumberOfMessagesToRetrieve 2 -ReceiveType PeekOnly
+            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty 2 -ReceiveType PeekOnly
             $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter)
         }
 
         It "should write warning message notifying the user that they should use PeekOnly instead of ReceiveAndKeep" {
             $queue = $queues[4]
-            $temp = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -NumberOfMessagesToRetrieve 2 -ReceiveType ReceiveAndKeep 3>&1 
+            $temp = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty 2 -ReceiveType ReceiveAndKeep 3>&1 
             $temp[0].Message | Should -Be "The option ReceiveAndKeep will be deprecated in future versions. Please use 'PeekOnly' instead."
         }
 
         It "should leave messages in the queue after being received if -ReceiveType is ReceiveAndKeep" {
             $queue = $queues[4]
-            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -NumberOfMessagesToRetrieve 2 -ReceiveType ReceiveAndKeep
+            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty 2 -ReceiveType ReceiveAndKeep
             $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter)
         }
 
         It "should remove messages from the queue after being received if -ReceiveType ReceiveAndDelete is supplied" {
             $queue = $queues[4]
             $messagesToRemove = 2
-            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -NumberOfMessagesToRetrieve $messagesToRemove -ReceiveType ReceiveAndDelete
+            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty $messagesToRemove -ReceiveType ReceiveAndDelete
             Start-Sleep -Seconds 1
             $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter - $messagesToRemove)
         }
@@ -138,7 +138,7 @@ Describe "Receive-SbMessage tests" {
         It "should receive messages from the dead letter queue if -ReceiveFromDeadLetterQueue is supplied" {
             $queue = $queues[5]
             $messagesToReceive = 1
-            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -NumberOfMessagesToRetrieve $messagesToReceive -ReceiveType ReceiveAndDelete -ReceiveFromDeadLetterQueue
+            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty $messagesToReceive -ReceiveType ReceiveAndDelete -ReceiveFromDeadLetterQueue
             Start-Sleep -Seconds 1
             $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.DeadLetterMessageCount | Should -Be ($messagesToDeadLetter - $messagesToReceive)
         }
@@ -146,29 +146,29 @@ Describe "Receive-SbMessage tests" {
 
     Context "Test receiving from a subscription" {
 
-        It "should receive a single message if -NumberOfMessagesToRetrieve is not supplied" {
+        It "should receive a single message if -ReceiveQty is not supplied" {
             $subscription = $subscriptions[0]
             $result = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription
             $result.count | Should -Be 1
         }
 
-        It "should receive the correct number of messages if -NumberOfMessagesToRetrieve is supplied" -TestCases @{messages = 2}, @{messages = 3} {
+        It "should receive the correct number of messages if -ReceiveQty is supplied" -TestCases @{messages = 2}, @{messages = 3} {
             param ([int] $messages)
             $subscription = $subscriptions[1]
-            $result = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -NumberOfMessagesToRetrieve $messages
+            $result = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -ReceiveQty $messages
             $result.count | Should -Be $messages
         }
 
         It "should leave messages in the subscription after being received if -ReceiveType is not supplied" {
             $subscription = $subscriptions[2]
-            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -NumberOfMessagesToRetrieve 2
+            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -ReceiveQty 2
             $ServiceBusUtils.GetSubscriptionRuntimeInfo($testTopic, $subscription).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter)
         }
 
         It "should remove messages from the subscription after being received if -ReceiveType ReceiveAndDelete is supplied" {
             $subscription = $subscriptions[2]
             $messagesToRemove = 2
-            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -NumberOfMessagesToRetrieve $messagesToRemove -ReceiveType ReceiveAndDelete
+            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -ReceiveQty $messagesToRemove -ReceiveType ReceiveAndDelete
             Start-Sleep -Seconds 1
             $ServiceBusUtils.GetSubscriptionRuntimeInfo($testTopic, $subscription).MessageCountDetails.ActiveMessageCount | Should -Be ($messagesToSendToEachEntity - $messagesToDeadLetter - $messagesToRemove)
         }
@@ -176,7 +176,7 @@ Describe "Receive-SbMessage tests" {
         It "should receive messages from the dead letter queue if -ReceiveFromDeadLetterQueue is supplied" {
             $subscription = $subscriptions[3]
             $messagesToReceive = 1
-            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -NumberOfMessagesToRetrieve $messagesToReceive -ReceiveType ReceiveAndDelete -ReceiveFromDeadLetterQueue
+            Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -TopicName $testTopic -SubscriptionName $subscription -ReceiveQty $messagesToReceive -ReceiveType ReceiveAndDelete -ReceiveFromDeadLetterQueue
             Start-Sleep -Seconds 1
             $ServiceBusUtils.GetSubscriptionRuntimeInfo($testTopic, $subscription).MessageCountDetails.DeadLetterMessageCount | Should -Be ($messagesToDeadLetter - $messagesToReceive)
         }

--- a/tests/integration/Receive-SbMessage.tests.ps1
+++ b/tests/integration/Receive-SbMessage.tests.ps1
@@ -11,7 +11,7 @@ Describe "Receive-SbMessage tests" {
 
     # create some queues, topics and subscriptions and allow time for it to complete
 
-    $queues = $ServiceBusUtils.CreateQueues(6)
+    $queues = $ServiceBusUtils.CreateQueues(7)
 
     $testTopic = (New-Guid).Guid
     $ServiceBusUtils.CreateTopic($testTopic)
@@ -141,6 +141,13 @@ Describe "Receive-SbMessage tests" {
             Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -ReceiveQty $messagesToReceive -ReceiveType ReceiveAndDelete -ReceiveFromDeadLetterQueue
             Start-Sleep -Seconds 1
             $ServiceBusUtils.GetQueueRuntimeInfo($queue).MessageCountDetails.DeadLetterMessageCount | Should -Be ($messagesToDeadLetter - $messagesToReceive)
+        }
+
+        It "should receive the correct number of messages if -NumberOfMessagesToRetrieve (alias) is supplied" -TestCases @{messages = 2}, @{messages = 3} {
+            param ([int] $messages)
+            $queue = $queues[6]
+            $result = Receive-SbMessage -NamespaceConnectionString $ServiceBusUtils.NamespaceConnectionString -QueueName $queue -NumberOfMessagesToRetrieve $messages
+            $result.count | Should -Be $messages
         }
     }
 


### PR DESCRIPTION
When looking at the naming convention for the Get-SbMessage, the following is true:

The end user want to read message(s) from a Service Bus Queue or a Service Bus Topic / Subscription. 

It shouldn't be necessary for us to be that explicit with the NumberOfMessagesToRetrieve parameter versus ReceiveQty.

